### PR TITLE
Use bash to call deploy-tacker-demo instead of sh

### DIFF
--- a/contrib/demos/tacker/deploy-tacker-demo-sfc
+++ b/contrib/demos/tacker/deploy-tacker-demo-sfc
@@ -57,7 +57,7 @@ EOF
 }
 
 function deploy_sfc {
-    sh ./deploy-tacker-demo
+    bash ./deploy-tacker-demo
     create_servers
     sfc_gen_config
     echo "Creating VNFFGD"


### PR DESCRIPTION
In a Ubuntu 16.04 server, run docker-tacker-demo-sfc will get this error:
`./deploy-tacker-demo: 3: ./deploy-tacker-demo: function: not found`
This commit will fix it by calling deploy-tacker-demo from deploy-tacker-demo-sfc using bash instead of sh.